### PR TITLE
20180331 fc logging refactoring

### DIFF
--- a/include/fc/log/log_message.hpp
+++ b/include/fc/log/log_message.hpp
@@ -40,7 +40,7 @@ namespace fc
          log_level( values v = off ):value(v){}
          explicit log_level( int v ):value( static_cast<values>(v)){}
          operator int()const { return value; }
-         values value;
+         values value = log_level::off;
    };
 
    void to_variant( log_level e, variant& v );

--- a/include/fc/log/logger.hpp
+++ b/include/fc/log/logger.hpp
@@ -43,12 +43,10 @@ namespace fc
          void  set_name( const fc::string& n );
          const fc::string& name()const;
 
-         void add_appender( const fc::shared_ptr<appender>& a );
-         std::vector<fc::shared_ptr<appender> > get_appenders()const;
-         void remove_appender( const fc::shared_ptr<appender>& a );
+         void add_appender( const log_level& log_level, const fc::shared_ptr<appender>& a );
 
          bool is_enabled( log_level e )const;
-         void log( log_message m );
+         void log( const log_level& log_level, log_message m );
 
       private:
          class impl;
@@ -77,31 +75,31 @@ namespace fc
 #define fc_dlog( LOGGER, FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (LOGGER).is_enabled( fc::log_level::debug ) ) \
-      (LOGGER).log( FC_LOG_MESSAGE( debug, FORMAT, __VA_ARGS__ ) ); \
+      (LOGGER).log( fc::log_level::debug, FC_LOG_MESSAGE( debug, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 #define fc_ilog( LOGGER, FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (LOGGER).is_enabled( fc::log_level::info ) ) \
-      (LOGGER).log( FC_LOG_MESSAGE( info, FORMAT, __VA_ARGS__ ) ); \
+      (LOGGER).log( fc::log_level::info, FC_LOG_MESSAGE( info, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 #define fc_wlog( LOGGER, FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (LOGGER).is_enabled( fc::log_level::warn ) ) \
-      (LOGGER).log( FC_LOG_MESSAGE( warn, FORMAT, __VA_ARGS__ ) ); \
+      (LOGGER).log( fc::log_level::warn, FC_LOG_MESSAGE( warn, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 #define fc_elog( LOGGER, FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (LOGGER).is_enabled( fc::log_level::error ) ) \
-      (LOGGER).log( FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ ) ); \
+      (LOGGER).log( fc::log_level::error, FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 #define dlog( FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (fc::logger::get(DEFAULT_LOGGER)).is_enabled( fc::log_level::debug ) ) \
-      (fc::logger::get(DEFAULT_LOGGER)).log( FC_LOG_MESSAGE( debug, FORMAT, __VA_ARGS__ ) ); \
+      (fc::logger::get(DEFAULT_LOGGER)).log( fc::log_level::debug, FC_LOG_MESSAGE( debug, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 /**
@@ -111,26 +109,26 @@ namespace fc
 #define ulog( FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (fc::logger::get("user")).is_enabled( fc::log_level::debug ) ) \
-      (fc::logger::get("user")).log( FC_LOG_MESSAGE( debug, FORMAT, __VA_ARGS__ ) ); \
+      (fc::logger::get("user")).log( fc::log_level::debug, FC_LOG_MESSAGE( debug, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 
 #define ilog( FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (fc::logger::get(DEFAULT_LOGGER)).is_enabled( fc::log_level::info ) ) \
-      (fc::logger::get(DEFAULT_LOGGER)).log( FC_LOG_MESSAGE( info, FORMAT, __VA_ARGS__ ) ); \
+      (fc::logger::get(DEFAULT_LOGGER)).log( fc::log_level::info, FC_LOG_MESSAGE( info, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 #define wlog( FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (fc::logger::get(DEFAULT_LOGGER)).is_enabled( fc::log_level::warn ) ) \
-      (fc::logger::get(DEFAULT_LOGGER)).log( FC_LOG_MESSAGE( warn, FORMAT, __VA_ARGS__ ) ); \
+      (fc::logger::get(DEFAULT_LOGGER)).log( fc::log_level::warn, FC_LOG_MESSAGE( warn, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 #define elog( FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (fc::logger::get(DEFAULT_LOGGER)).is_enabled( fc::log_level::error ) ) \
-      (fc::logger::get(DEFAULT_LOGGER)).log( FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ ) ); \
+      (fc::logger::get(DEFAULT_LOGGER)).log( fc::log_level::error, FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
 
 #include <boost/preprocessor/seq/for_each.hpp>

--- a/src/log/logger.cpp
+++ b/src/log/logger.cpp
@@ -97,7 +97,12 @@ namespace fc {
     logger& logger::set_parent(const logger& p) { my->_parent = p; return *this; }
 
     log_level logger::get_log_level()const { return my->_level; }
-    logger& logger::set_log_level(log_level ll) { my->_level = ll; return *this; }
+    logger& logger::set_log_level(log_level ll)
+    {
+        if (ll < my->_level)
+            my->_level = ll;
+        return *this;
+    }
 
     void logger::add_appender(const log_level& log_level, const fc::shared_ptr<appender>& a)
     {

--- a/src/log/logger.cpp
+++ b/src/log/logger.cpp
@@ -21,7 +21,7 @@ namespace fc {
          bool             _additivity;
          log_level        _level;
 
-         std::vector<appender::ptr> _appenders;
+        std::map<log_level::values, std::vector<appender::ptr>, std::greater<log_level::values>> _appenders;
     };
 
 
@@ -61,15 +61,18 @@ namespace fc {
        return e >= my->_level;
     }
 
-    void logger::log( log_message m ) {
-       m.get_context().append_context( my->_name );
+    void logger::log(const log_level& log_level, log_message m) {
+        m.get_context().append_context(my->_name);
 
-       for( auto itr = my->_appenders.begin(); itr != my->_appenders.end(); ++itr )
-          (*itr)->log( m );
+        auto most_strong_suitable_level_it = my->_appenders.lower_bound(log_level.value);
+        for (auto it = most_strong_suitable_level_it; it != my->_appenders.end(); ++it)
+            for (const auto& appender : it->second)
+                appender->log(m);
 
-       if( my->_additivity && my->_parent != nullptr) {
-          my->_parent.log(m);
-       }
+        if (my->_additivity && my->_parent != nullptr)
+        {
+            my->_parent.log(log_level, m);
+        }
     }
     void logger::set_name( const fc::string& n ) { my->_name = n; }
     const fc::string& logger::name()const { return my->_name; }
@@ -96,15 +99,9 @@ namespace fc {
     log_level logger::get_log_level()const { return my->_level; }
     logger& logger::set_log_level(log_level ll) { my->_level = ll; return *this; }
 
-    void logger::add_appender( const fc::shared_ptr<appender>& a )
-    { my->_appenders.push_back(a); }
-    
-//    void logger::remove_appender( const fc::shared_ptr<appender>& a )
- //   { my->_appenders.erase(a); }
-
-    std::vector<fc::shared_ptr<appender> > logger::get_appenders()const
+    void logger::add_appender(const log_level& log_level, const fc::shared_ptr<appender>& a)
     {
-        return my->_appenders;
+        my->_appenders[log_level.value].push_back(a);
     }
 
    bool configure_logging( const logging_config& cfg );

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -9,6 +9,7 @@
 #include <fc/reflect/variant.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/io/stdio.hpp>
+#include <boost/algorithm/cxx11/copy_if.hpp>
 
 namespace fc {
    extern std::unordered_map<std::string,logger>& get_logger_map();
@@ -32,21 +33,28 @@ namespace fc {
          appender::create( cfg.appenders[i].name, cfg.appenders[i].type, cfg.appenders[i].args );
         // TODO... process enabled
       }
-      for( size_t i = 0; i < cfg.loggers.size(); ++i ) {
-         auto lgr = logger::get( cfg.loggers[i].name );
 
-         // TODO: finish configure logger here...
-         if( cfg.loggers[i].parent.valid() ) {
-            lgr.set_parent( logger::get( *cfg.loggers[i].parent ) );
-         }
-         lgr.set_name(cfg.loggers[i].name);
-         if( cfg.loggers[i].level.valid() ) lgr.set_log_level( *cfg.loggers[i].level );
-         
-
-         for( auto a = cfg.loggers[i].appenders.begin(); a != cfg.loggers[i].appenders.end(); ++a ){
-            auto ap = appender::get( *a );
-            if( ap ) { lgr.add_appender(ap); }
-         }
+      std::vector<logger_config> loggers;
+      boost::algorithm::copy_if(cfg.loggers, std::back_inserter(loggers),
+                                [](const logger_config& lhs) { return lhs.level.valid(); });
+      for (size_t i = 0; i < loggers.size(); ++i)
+      {
+          const auto& logger_cfg = loggers[i];
+          auto logger = logger::get(logger_cfg.name);
+          logger.set_name(logger_cfg.name);
+          logger.set_log_level(*logger_cfg.level);
+          if (logger_cfg.parent.valid())
+          {
+              logger.set_parent(logger::get(*logger_cfg.parent));
+          }
+          for (const auto& appender_name : logger_cfg.appenders)
+          {
+              auto appender = appender::get(appender_name);
+              if (appender)
+              {
+                  logger.add_appender(*logger_cfg.level, appender);
+              }
+          }
       }
       return reg_console_appender || reg_file_appender;
       } catch ( exception& e )


### PR DESCRIPTION
Old behavior:
- info     'default' logger logs into stdout --> all **DEBUG**&info logs go into stdout (**wrong**)
- debug 'default' logger logs into 'file'     --> all debug&info logs go into 'file' (as expected)
New behavior:
- info     'default' logger logs into stdout --> only info logs go into stdout (as expected)
- debug 'default' logger logs into 'file'     --> all debug&info logs go into 'file' (as expected)